### PR TITLE
[finishes #170122463] reject-incident-endpoint-and-Tests

### DIFF
--- a/Server/v2/controller/adminController.js
+++ b/Server/v2/controller/adminController.js
@@ -29,6 +29,34 @@ class adminController {
       error: 'Forbidden route',
     });
   }
+
+  static async rejectFlag(req, res) {
+    const {
+      status,
+    } = req.body;
+    const incidentId = parseInt(req.params.incidentid);
+    const userType = req.user.type;
+    if (userType === 'Admin') {
+      const findIncident = await conn.query(adminQuery.findToUpdate, [incidentId]);
+      if (findIncident.rowCount > 0) {
+        await conn.query(adminQuery.reject, [status, incidentId]);
+        const show = await conn.query(adminQuery.findSpecific, [incidentId]);
+        return res.status(200).json({
+          status: 200,
+          message: 'Incident is rejected',
+          data: show.rows[0],
+        });
+      }
+      return res.status(404).json({
+        status: 404,
+        error: 'Sorry, Incident not found',
+      });
+    }
+    return res.status(403).json({
+      status: 403,
+      error: 'Forbidden route',
+    });
+  }
 }
 
 export default adminController;

--- a/Server/v2/middleware/validation.js
+++ b/Server/v2/middleware/validation.js
@@ -100,5 +100,19 @@ class validation {
     }
     next();
   }
+
+  static rejectVal(req, res, next) {
+    const Schema = joi.object({
+      status: joi.string().valid('draft', 'under investigation', 'rejected').required(),
+    });
+    const { error } = Schema.validate(req.body);
+    if (error) {
+      return res.status(400).json({
+        status: 400,
+        error: error.details[0].message.replace(/"/g, ''),
+      });
+    }
+    next();
+  }
 }
 export default validation;

--- a/Server/v2/routes/routes.js
+++ b/Server/v2/routes/routes.js
@@ -17,4 +17,5 @@ app.delete('/api/v2/red-flag/Delete/:incidentid', auth, incidentController.delet
 app.patch('/api/v2/red-flag/Location/:incidentid', auth, validation.locationVal, incidentController.updateLocation);
 app.patch('/api/v2/red-flag/Comment/:incidentid', auth, validation.commentVal, incidentController.updateComment);
 app.patch('/api/v2/red-flag/Status/:incidentid', auth, validation.statusVal, adminController.acceptFlag);
+app.patch('/api/v2/red-flag/Reject/:incidentid', auth, validation.rejectVal, adminController.rejectFlag);
 export default app;

--- a/Server/v2/test/otherTests.js
+++ b/Server/v2/test/otherTests.js
@@ -70,4 +70,38 @@ describe('Admin Tests', () => {
         done();
       });
   });
+  // ================ ADMIN REJECT INCIDENT TESTS =============
+  it('should be able to reject if admin', (done) => {
+    Chai.request(app)
+      .patch('/api/v2/red-flag/Reject/2')
+      .set('token', adminToken)
+      .send({ status: 'rejected' })
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.property('message', 'Incident is rejected');
+        done();
+      });
+  });
+  it('should not be able to reject if it does not exist', (done) => {
+    Chai.request(app)
+      .patch('/api/v2/red-flag/Reject/20')
+      .set('token', adminToken)
+      .send({ status: 'rejected' })
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.have.property('error', 'Sorry, Incident not found');
+        done();
+      });
+  });
+  it('should not be able to reject if not admin', (done) => {
+    Chai.request(app)
+      .patch('/api/v2/red-flag/Reject/1')
+      .set('token', userToken)
+      .send({ status: 'rejected' })
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.should.have.property('error', 'Forbidden route');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
This PR includes rejecting incident endpoint and its tests.
#### Description of Task to be completed?
#### Have the following endpoint working:
- PATCH /API/v2/red-flag/Reject/incident-id
As an admin, I should be able to reject an incident that is deemed inappropriate.
An incident can be a red flag or intervention record.
#### How should this be manually tested?
Clone this app to your local machine, then "use npm install" to install all the dependencies
Use npm run dev or npm start to run it and then use Postman to test this endpoint.
Use npm test to run tests.
#### What are the relevant pivotal tracker stories?
- [#170122463](https://www.pivotaltracker.com/story/show/170122463)